### PR TITLE
Add libnativehelper and libcore

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -618,6 +618,8 @@ subdirs := \
 	frameworks/rs/cpp \
 	frameworks/compile/slang \
 	hardware \
+	libnativehelper \
+	libcore \
 	prebuilts/tools/linux-x86/sdl \
 	prebuilts/sdk/tools \
 	sdk/emulator \


### PR DESCRIPTION
Fixes the failure introduced with the recent LOS merge

Change-Id: I4cfbfdc0cec53dd0293688b169ab1e3b4136c2c6