### PR TITLE
Add halium-boot to main.mk

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -654,7 +654,8 @@ subdirs += \
 # Specific projects for Halium
 subdirs += \
 	halium/hybris-boot \
-	halium/droidmedia
+	halium/droidmedia \
+	halium/halium-boot
 
 FULL_BUILD := true
 


### PR DESCRIPTION
Looks like this is only required for 7.1, which is always a plus. :)

Depends on https://github.com/Halium/android/pull/23 being merged