### PR TITLE
main: Add subdirs for UBports

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -654,7 +654,10 @@ subdirs += \
 # Specific projects for Halium
 subdirs += \
 	halium/hybris-boot \
-	halium/droidmedia \
+	halium/libhybris \
+	external/droidmedia \
+	halium/audioflingerglue \
+	halium/platform-api \
 	halium/halium-boot
 
 FULL_BUILD := true


### PR DESCRIPTION
This adds:
- droidmedia for libminisf
- audioflingerglue for certain devices
- libhybris & platform-api for sensor support

The components to be built have to be specified
in the device configuration makefiles.