### PR TITLE
Enable components required for camera support

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -595,6 +595,7 @@ subdirs := \
 	frameworks/av/services/audiopolicy \
 	frameworks/av/services/medialog \
 	frameworks/av/services/mediacodec \
+	frameworks/av/services/mediaextractor \
 	frameworks/av/services/mediaresourcemanager \
 	frameworks/av/services/camera/libcameraservice \
 	frameworks/av/soundtrigger \

--- a/target/product/core_base.mk
+++ b/target/product/core_base.mk
@@ -80,7 +80,9 @@ PRODUCT_PACKAGES += \
     libsf_compat_layer \
     libui_compat_layer \
     libubuntu_application_api \
-    upstart-property-watcher
+    upstart-property-watcher \
+    libdroidmedia \
+    miniafservice
 
 # for testing
 PRODUCT_PACKAGES += \

--- a/target/product/core_base.mk
+++ b/target/product/core_base.mk
@@ -70,7 +70,7 @@ PRODUCT_PACKAGES += \
     healthd \
     logd
 
-# for Ubuntu Touch (hybris, platform-api, utils, etc)
+# for Halium (hybris, platform-api, utils, etc)
 PRODUCT_PACKAGES += \
     apns-conf.xml \
     libcamera_compat_layer \


### PR DESCRIPTION
This PR enables a few components required for camera support. These components are:
- mediaextractor service: used by mediaplayer service.
- miniaf: used for shutter sound? But we need it for another reason anyway (qcom rild->audio chipset communication for voice calling), we might also enable it now.