### PR TITLE
Add harfbuzz, minikin and unicode

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -507,6 +507,7 @@ subdirs := \
 	external/giflib \
 	external/gtest \
 	external/gptfdisk \
+	external/harfbuzz_ng \
 	external/ntfs-3g \
 	external/piex \
 	external/f2fs-tools \
@@ -568,6 +569,7 @@ subdirs := \
 	external/tinycompress \
 	external/tinyalsa \
 	external/tremolo \
+	external/unicode \
 	external/webp \
 	external/webrtc \
 	external/wpa_supplicant_6 \
@@ -607,6 +609,7 @@ subdirs := \
 	frameworks/base/libs/storage \
 	frameworks/base/tools/aapt \
 	frameworks/base/native/android \
+	frameworks/minikin \
 	frameworks/native/cmds/installd \
 	frameworks/native/cmds/sensorservice \
 	frameworks/native/cmds/servicemanager \


### PR DESCRIPTION
These libraries are sometimes needed by some vendor binaries, like the
camera HAL vendor blob on tissot.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
Change-Id: I754ea59f09c0ddf3d153264dd3d95a071625c378