### PR TITLE
Adapt symlink creation for devices with awkward vendor partition

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1322,7 +1322,7 @@ $(hide) if [ -d $(TARGET_OUT)/vendor ] && [ ! -h $(TARGET_OUT)/vendor ]; then \
   echo 'You cannot install files to $(TARGET_OUT)/vendor while building a separate vendor.img!' 1>&2; \
   exit 1; \
 fi
-$(hide) ln -sf /vendor $(TARGET_OUT)/vendor
+$(hide) ln -sf ../vendor $(TARGET_OUT)/vendor
 endef
 else
 define create-system-vendor-symlink
@@ -1337,7 +1337,7 @@ $(hide) if [ -d $(TARGET_OUT)/vendor ] && [ ! -h $(TARGET_OUT)/vendor ]; then \
   echo 'You cannot install files to $(TARGET_OUT)/vendor while building a separate vendor.img!' 1>&2; \
   exit 1; \
 fi
-$(hide) ln -sf /vendor $(TARGET_OUT)/vendor
+$(hide) ln -sf ../vendor $(TARGET_OUT)/vendor
 endef
 endif
 


### PR DESCRIPTION
Option `BOARD_NEEDS_VENDORIMAGE_SYMLINK` is set in BoardConfig.mk for some 7.1 devices.

This is a weird one: Nexus 6P and probably other devices use this option to create a special symlink to do /system/vendor -> /vendor, which will break as we mount this in /android/vendor instead, and /vendor goes to /system/vendor again, creating a loop. This PR will instead redirect the request to the real partition mounted in /android/vendor.

Another option would be to not correct this problem here but let the root fs not point /vendor => system/vendor but instead directly to /android/vendor. This however might break older classic devices without Halium, and is more risky than just changing it here for the devices that use. 

Option `BOARD_USES_VENDORIMAGE` apparently does the same, this is why I also fix it here in the same way.
